### PR TITLE
Add action_type argument to log and log_bulk

### DIFF
--- a/lib/ecto_trail/ecto_trail.ex
+++ b/lib/ecto_trail/ecto_trail.ex
@@ -49,8 +49,12 @@ defmodule EctoTrail do
   alias Ecto.Multi
   require Logger
 
+  @type action_type :: :insert | :update | :upsert | :delete
+
   defmacro __using__(_) do
     quote do
+      @type action_type :: :insert | :update | :upsert | :delete
+
       @doc """
       Store changes in a `change_log` table.
       """
@@ -58,7 +62,7 @@ defmodule EctoTrail do
               struct_or_changeset :: Ecto.Schema.t() | Ecto.Changeset.t(),
               changes :: Map.t(),
               actor_id :: String.T,
-              action_type :: :insert | :update | :upsert | :delete
+              action_type :: action_type()
             ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
       def log(struct_or_changeset, changes, actor_id, action_type),
         do: EctoTrail.log(__MODULE__, struct_or_changeset, changes, actor_id, action_type)
@@ -70,7 +74,7 @@ defmodule EctoTrail do
               structs :: list(Ecto.Schema.t()),
               changes :: list(Map.t()),
               actor_id :: String.T,
-              action_type :: :insert | :update | :upsert | :delete
+              action_type :: action_type()
             ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
       def log_bulk(structs, changes, actor_id, action_type),
         do: EctoTrail.log_bulk(__MODULE__, structs, changes, actor_id, action_type)
@@ -141,7 +145,7 @@ defmodule EctoTrail do
           struct_or_changeset :: Ecto.Schema.t() | Ecto.Changeset.t(),
           changes :: Map.t(),
           actor_id :: String.T,
-          action_type :: :insert | :update | :upsert | :delete
+          action_type :: action_type()
         ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def log(repo, struct_or_changeset, changes, actor_id, action_type) do
     Multi.new()
@@ -157,7 +161,7 @@ defmodule EctoTrail do
           structs :: list(Ecto.Schema.t()),
           changes :: list(Map.t()),
           actor_id :: String.T,
-          action_type :: :insert | :update | :upsert | :delete
+          action_type :: action_type()
         ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def log_bulk(repo, structs, changes, actor_id, action_type) do
     Enum.zip(structs, changes)

--- a/test/unit/ecto_trail_log_only_test.exs
+++ b/test/unit/ecto_trail_log_only_test.exs
@@ -62,6 +62,15 @@ defmodule EctoTrailLogOnlyTest do
         "cowboy",
         :delete
       )
+
+      Enum.each(Enum.zip([ids, changeset_like_maps]), fn {an_id, a_change} ->
+        assert %{
+                 changeset: a_change,
+                 actor_id: "cowboy",
+                 change_type: :delete
+               } =
+                 TestRepo.get_by(Changelog, %{resource_id: an_id |> to_string(), change_type: :delete})
+      end)
     end
   end
 end

--- a/test/unit/ecto_trail_log_only_test.exs
+++ b/test/unit/ecto_trail_log_only_test.exs
@@ -20,6 +20,7 @@ defmodule EctoTrailLogOnlyTest do
 
       {_n, structs_list} = TestRepo.insert_all(Resource, ready_changes, returning: true)
 
+      # logging inserted
       result = TestRepo.log_bulk(structs_list, changes_list, "cowboy", :insert)
 
       ids = Enum.map(structs_list, fn inserted_struct -> inserted_struct.id end)
@@ -33,6 +34,34 @@ defmodule EctoTrailLogOnlyTest do
                  change_type: :insert
                } = TestRepo.get_by(Changelog, %{resource_id: an_id |> to_string()})
       end)
+
+      # logging deleted
+      {_n, deleted_objects_list} = TestRepo.delete_all(from(s in Resource, where: s.id in ^ids, select: s))
+
+      associations = (fn s -> s.__struct__.__schema__(:associations) end).(struct(Resource))
+
+      changeset_like_maps =
+        Enum.map(
+          deleted_objects_list,
+          fn deleted_object ->
+            Map.from_struct(deleted_object)
+            |> Map.delete(:__meta__)
+            |> Enum.reduce(%{}, fn {key, value}, acc ->
+              if key in associations do
+                Map.put(acc, key, nil)
+              else
+                Map.put(acc, key, value)
+              end
+            end)
+          end
+        )
+
+      TestRepo.log_bulk(
+        deleted_objects_list,
+        changeset_like_maps,
+        "cowboy",
+        :delete
+      )
     end
   end
 end

--- a/test/unit/ecto_trail_log_only_test.exs
+++ b/test/unit/ecto_trail_log_only_test.exs
@@ -20,7 +20,7 @@ defmodule EctoTrailLogOnlyTest do
 
       {_n, structs_list} = TestRepo.insert_all(Resource, ready_changes, returning: true)
 
-      result = TestRepo.log_bulk(structs_list, changes_list, "cowboy")
+      result = TestRepo.log_bulk(structs_list, changes_list, "cowboy", :insert)
 
       ids = Enum.map(structs_list, fn inserted_struct -> inserted_struct.id end)
 


### PR DESCRIPTION
# Description

This version adds `action_type :: :insert | :update | :upsert | :delete` argument to `log` and `log_bulk` to specify the action to be logged.

Fixes # ([THBK-661](https://linear.app/valiot/issue/THBK-661/add-support-for-providing-action-type-on-ecto-trail-log-bulk))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Test `test/unit/ecto_trail_log_only_test.exs` modified to include the new argument. Nothing broken.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
