### PR TITLE
Fix nested multi transaction

### DIFF
--- a/lib/ecto_trail/ecto_trail.ex
+++ b/lib/ecto_trail/ecto_trail.ex
@@ -154,9 +154,22 @@ defmodule EctoTrail do
           action_type :: action_type()
         ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def log(repo, struct_or_changeset, changes, actor_id, action_type) do
-    Multi.new()
-    |> Multi.run(:operation, fn _, _ -> {:ok, struct_or_changeset} end)
-    |> run_logging_transaction_alone(repo, struct_or_changeset, changes, actor_id, action_type)
+    if repo.in_transaction?() do
+      log_changes_alone(
+        repo,
+        %{operation: struct_or_changeset},
+        struct_or_changeset,
+        changes,
+        actor_id,
+        action_type
+      )
+
+      {:ok, struct_or_changeset}
+    else
+      Multi.new()
+      |> Multi.run(:operation, fn _, _ -> {:ok, struct_or_changeset} end)
+      |> run_logging_transaction_alone(repo, struct_or_changeset, changes, actor_id, action_type)
+    end
   end
 
   @doc """
@@ -276,9 +289,16 @@ defmodule EctoTrail do
           opts :: Keyword.t()
         ) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def insert_and_log(repo, struct_or_changeset, actor_id, opts \\ []) do
-    Multi.new()
-    |> Multi.insert(:operation, struct_or_changeset, opts)
-    |> run_logging_transaction(repo, struct_or_changeset, actor_id, :insert)
+    if repo.in_transaction?() do
+      with {:ok, operation} <- repo.insert(struct_or_changeset, opts) do
+        log_changes(repo, %{operation: operation}, struct_or_changeset, actor_id, :insert)
+        {:ok, operation}
+      end
+    else
+      Multi.new()
+      |> Multi.insert(:operation, struct_or_changeset, opts)
+      |> run_logging_transaction(repo, struct_or_changeset, actor_id, :insert)
+    end
   end
 
   @doc """
@@ -295,9 +315,16 @@ defmodule EctoTrail do
           {:ok, Ecto.Schema.t()}
           | {:error, Ecto.Changeset.t()}
   def update_and_log(repo, changeset, actor_id, opts \\ []) do
-    Multi.new()
-    |> Multi.update(:operation, changeset, opts)
-    |> run_logging_transaction(repo, changeset, actor_id, :update)
+    if repo.in_transaction?() do
+      with {:ok, operation} <- repo.update(changeset, opts) do
+        log_changes(repo, %{operation: operation}, changeset, actor_id, :update)
+        {:ok, operation}
+      end
+    else
+      Multi.new()
+      |> Multi.update(:operation, changeset, opts)
+      |> run_logging_transaction(repo, changeset, actor_id, :update)
+    end
   end
 
   @doc """
@@ -314,9 +341,16 @@ defmodule EctoTrail do
           {:ok, Ecto.Schema.t()}
           | {:error, Ecto.Changeset.t()}
   def upsert_and_log(repo, struct_or_changeset, actor_id, opts \\ []) do
-    Multi.new()
-    |> Multi.insert_or_update(:operation, struct_or_changeset, opts)
-    |> run_logging_transaction(repo, struct_or_changeset, actor_id, :upsert)
+    if repo.in_transaction?() do
+      with {:ok, operation} <- repo.insert_or_update(struct_or_changeset, opts) do
+        log_changes(repo, %{operation: operation}, struct_or_changeset, actor_id, :upsert)
+        {:ok, operation}
+      end
+    else
+      Multi.new()
+      |> Multi.insert_or_update(:operation, struct_or_changeset, opts)
+      |> run_logging_transaction(repo, struct_or_changeset, actor_id, :upsert)
+    end
   end
 
   @doc """
@@ -331,9 +365,16 @@ defmodule EctoTrail do
           {:ok, Ecto.Schema.t()}
           | {:error, Ecto.Changeset.t()}
   def delete_and_log(repo, struct_or_changeset, actor_id, opts \\ []) do
-    Multi.new()
-    |> Multi.delete(:operation, struct_or_changeset, opts)
-    |> run_logging_transaction(repo, struct_or_changeset, actor_id, :delete)
+    if repo.in_transaction?() do
+      with {:ok, operation} <- repo.delete(struct_or_changeset, opts) do
+        log_changes(repo, %{operation: operation}, struct_or_changeset, actor_id, :delete)
+        {:ok, operation}
+      end
+    else
+      Multi.new()
+      |> Multi.delete(:operation, struct_or_changeset, opts)
+      |> run_logging_transaction(repo, struct_or_changeset, actor_id, :delete)
+    end
   end
 
   defp run_logging_transaction(multi, repo, struct_or_changeset, actor_id, operation_type) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule EctoTrail.Mixfile do
   use Mix.Project
 
-  @version "1.0.2"
+  @version "1.0.3"
 
   def project do
     [

--- a/test/unit/ecto_trail_test.exs
+++ b/test/unit/ecto_trail_test.exs
@@ -245,6 +245,90 @@ defmodule EctoTrailTest do
       assert [%{name: "name"}] = TestRepo.all(Resource)
       assert [] == TestRepo.all(Changelog)
     end
+
+    test "works with multiple sequential updates inside Multi", %{schema: schema} do
+      {:ok, schema2} = TestRepo.insert(%Resource{name: "second"})
+
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:update_first, fn _repo, _changes ->
+          schema
+          |> Changeset.change(%{name: "first updated"})
+          |> TestRepo.update_and_log("cowboy")
+        end)
+        |> Ecto.Multi.run(:update_second, fn _repo, _changes ->
+          schema2
+          |> Changeset.change(%{name: "second updated"})
+          |> TestRepo.update_and_log("cowboy")
+        end)
+
+      assert {:ok,
+              %{
+                update_first: %Resource{name: "first updated"},
+                update_second: %Resource{name: "second updated"}
+              }} = TestRepo.transaction(multi)
+
+      assert 2 == TestRepo.aggregate(Changelog, :count)
+    end
+  end
+
+  describe "insert_and_log/3 inside Ecto.Multi" do
+    test "works when called from within an Ecto.Multi.run callback" do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:insert_resource, fn _repo, _changes ->
+          %Resource{}
+          |> Changeset.change(%{name: "inserted inside multi"})
+          |> TestRepo.insert_and_log("cowboy")
+        end)
+
+      assert {:ok, %{insert_resource: %Resource{name: "inserted inside multi"}}} =
+               TestRepo.transaction(multi)
+
+      assert 1 == TestRepo.aggregate(Changelog, :count)
+    end
+  end
+
+  describe "upsert_and_log/3 inside Ecto.Multi" do
+    setup do
+      {:ok, schema} = TestRepo.insert(%Resource{name: "upsert-target"})
+      {:ok, %{schema: schema}}
+    end
+
+    test "works when called from within an Ecto.Multi.run callback", %{schema: schema} do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:upsert_resource, fn _repo, _changes ->
+          schema
+          |> Changeset.change(%{name: "upserted inside multi"})
+          |> TestRepo.upsert_and_log("cowboy")
+        end)
+
+      assert {:ok, %{upsert_resource: %Resource{name: "upserted inside multi"}}} =
+               TestRepo.transaction(multi)
+
+      assert 1 == TestRepo.aggregate(Changelog, :count)
+    end
+  end
+
+  describe "delete_and_log/3 inside Ecto.Multi" do
+    setup do
+      {:ok, schema} = TestRepo.insert(%Resource{name: "delete-target"})
+      {:ok, %{schema: schema}}
+    end
+
+    test "works when called from within an Ecto.Multi.run callback", %{schema: schema} do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:delete_resource, fn _repo, _changes ->
+          TestRepo.delete_and_log(schema, "cowboy")
+        end)
+
+      assert {:ok, %{delete_resource: %Resource{}}} = TestRepo.transaction(multi)
+
+      assert [] == TestRepo.all(Resource)
+      assert 1 == TestRepo.aggregate(Changelog, :count)
+    end
   end
 
   describe "upsert_and_log/3" do

--- a/test/unit/ecto_trail_test.exs
+++ b/test/unit/ecto_trail_test.exs
@@ -199,6 +199,54 @@ defmodule EctoTrailTest do
     end
   end
 
+  describe "update_and_log/3 inside Ecto.Multi" do
+    setup do
+      {:ok, schema} = TestRepo.insert(%Resource{name: "name"})
+      {:ok, %{schema: schema}}
+    end
+
+    test "works when called from within an Ecto.Multi.run callback", %{schema: schema} do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:update_resource, fn _repo, _changes ->
+          schema
+          |> Changeset.change(%{name: "updated inside multi"})
+          |> TestRepo.update_and_log("cowboy")
+        end)
+
+      assert {:ok, %{update_resource: %Resource{name: "updated inside multi"}}} =
+               TestRepo.transaction(multi)
+
+      resource = TestRepo.one(Resource)
+      resource_id = to_string(resource.id)
+
+      assert %{
+               changeset: %{"name" => "updated inside multi"},
+               actor_id: "cowboy",
+               resource_id: ^resource_id,
+               resource: "resources",
+               change_type: :update
+             } = TestRepo.one(Changelog)
+    end
+
+    test "returns error without crashing when update fails inside Multi", %{schema: schema} do
+      multi =
+        Ecto.Multi.new()
+        |> Ecto.Multi.run(:update_resource, fn _repo, _changes ->
+          schema
+          |> Changeset.change(%{name: "new name"})
+          |> Changeset.add_error(:name, "invalid")
+          |> TestRepo.update_and_log("cowboy")
+        end)
+
+      assert {:error, :update_resource, %Changeset{valid?: false}, _} =
+               TestRepo.transaction(multi)
+
+      assert [%{name: "name"}] = TestRepo.all(Resource)
+      assert [] == TestRepo.all(Changelog)
+    end
+  end
+
   describe "upsert_and_log/3" do
     setup do
       {:ok, schema} = TestRepo.insert(%Resource{name: "name"})


### PR DESCRIPTION
 
 The `*_and_log` functions (`update_and_log`, `insert_and_log`, etc.) internally create an `Ecto.Multi` and call `repo.transaction()`. When these functions are called from within an outer `Ecto.Multi.run` callback  as happens with valiot-app's `multiple_function_body` for batch mutations like `updateMultipleRecipe` this creates a nested Multi-inside Multi pattern.                                                     
  
This error path has existed since Ecto 3.0 (PR #2867). The crash surfaced now because the DISABLE_OLD_RECIPES operation triggered the updateMultipleRecipe → Ecto.Multi → update_and_log →  nested Ecto.Multi path for the first time in production.   

  ▎ "operation :rollback is rolling back unexpectedly... Nested transactions are discouraged when using 
  Ecto.Multi. Consider flattening out the transaction instead."
                                                                                                        
  Stack trace confirms the crash at `EctoTrail.run_logging_transaction/5` (line 342) called from `Ecto.Multi.apply_operation/5`.           
                                                                                                        
  ### Fix                                                                                                   
  
  Each `*_and_log` function and `log/5` now checks `repo.in_transaction?()`:                                  
                                                            
  - Already in a transaction: executes the repo operation and audit logging inline — no nested Multi or
 ` repo.transaction() `                                                                                   
  - Standalone (not in a transaction): uses the existing `Ecto.Multi` + `repo.transaction()` path (unchanged)                                                                                           
                                                            
  Both paths produce identical return types and audit log behavior.   

Fixes: [THBK-950](https://linear.app/valiot/issue/THBK-950/critical-schedule-logic-bydsa-prod-ecto-transaction-rollback-error-in)